### PR TITLE
Clean up PartitionSettings

### DIFF
--- a/gui/action.cpp
+++ b/gui/action.cpp
@@ -1739,9 +1739,11 @@ int GUIAction::flashimage(std::string arg __unused)
 
 	PartitionSettings part_settings;
 	operation_start("Flash Image");
-	DataManager::GetValue("tw_zip_location", part_settings.Restore_Name);
-	DataManager::GetValue("tw_file", part_settings.Backup_FileName);
-	unsigned long long total_bytes = TWFunc::Get_File_Size(part_settings.Restore_Name + "/" + part_settings.Backup_FileName);
+	string path, filename;
+	DataManager::GetValue("tw_zip_location", path);
+	DataManager::GetValue("tw_file", filename);
+	part_settings.Backup_Folder = path + "/" + filename;
+	unsigned long long total_bytes = TWFunc::Get_File_Size(part_settings.Backup_Folder);
 	ProgressTracking progress(total_bytes);
 	part_settings.progress = &progress;
 	part_settings.adbbackup = false;

--- a/openrecoveryscript.cpp
+++ b/openrecoveryscript.cpp
@@ -840,11 +840,10 @@ int OpenRecoveryScript::Restore_ADB_Backup(void) {
 					pos = Restore_Name.find_last_of("/");
 					Backup_FileName = Restore_Name.substr(pos + 1, Restore_Name.size());
 					part_settings.Part = PartitionManager.Find_Partition_By_Path(path);
-					part_settings.Restore_Name = path;
+					part_settings.Backup_Folder = path;
 					part_settings.partition_count = partition_count;
 					part_settings.adbbackup = true;
 					part_settings.adb_compression = twimghdr.compressed;
-					part_settings.Backup_FileName = Backup_FileName;
 					part_settings.PM_Method = PM_RESTORE;
 					ProgressTracking progress(part_settings.total_restore_size);
 					part_settings.progress = &progress;
@@ -871,7 +870,6 @@ int OpenRecoveryScript::Restore_ADB_Backup(void) {
 					pos = Restore_Name.find_last_of("/");
 					Backup_FileName = Restore_Name.substr(pos + 1, Restore_Name.size());
 					pos = Restore_Name.find_last_of("/");
-					part_settings.Restore_Name = Restore_Name.substr(0, pos);
 					part_settings.Part = PartitionManager.Find_Partition_By_Path(path);
 
 					if (path.compare("/system") == 0) {
@@ -893,7 +891,6 @@ int OpenRecoveryScript::Restore_ADB_Backup(void) {
 					part_settings.partition_count = partition_count;
 					part_settings.adbbackup = true;
 					part_settings.adb_compression = twimghdr.compressed;
-					part_settings.Backup_FileName = Backup_FileName;
 					part_settings.total_restore_size += part_settings.Part->Get_Restore_Size(&part_settings);
 					part_settings.PM_Method = PM_RESTORE;
 					ProgressTracking progress(part_settings.total_restore_size);

--- a/partitions.hpp
+++ b/partitions.hpp
@@ -44,11 +44,7 @@ class TWPartition;
 
 struct PartitionSettings {                                                         // Settings for backup session
 	TWPartition* Part;                                                         // Partition to pass to the partition backup loop
-	std::string Backup_Folder;                                                 // Backup folder to put backup into
-	std::string Full_Backup_Path;                                              // Path to the current backup storage setting
-	std::string Backup_Name;                                                   // Name of partition
-	std::string Restore_Name;                                                  // Path to restore folder
-	std::string Backup_FileName;                                               // Name of the file to restore
+	std::string Backup_Folder;                                                 // Path to restore folder
 	bool adbbackup;                                                            // tell the system we are backing up over adb
 	bool adb_compression;                                                      // 0 == uncompressed, 1 == compressed
 	bool generate_md5;                                                         // tell system to create md5 for partitions


### PR DESCRIPTION
The PartitionSettings struct contains some data elements that are duplicates
of data elements in the TWPartition class that is contained within the
PartitionsSettings.Part element. We will eliminate this duplication to help
reduce the chances for programming bugs.

Specifically, this fixes problems where the current file system does not
match the backed up file system.

Change-Id: I02f236e72093362050556a2e53a09d1dbb9a269d